### PR TITLE
Mobile Video Fix

### DIFF
--- a/app/art/dua-lipa-spotify/page.tsx
+++ b/app/art/dua-lipa-spotify/page.tsx
@@ -6,9 +6,14 @@
 import SimpleTopbar from "@/components/common/simple-topbar";
 import TitleImage from "@/components/common/title-image";
 import { MediaPlayer, MediaOutlet } from "@vidstack/react";
+import { MediaErrorEvent } from "vidstack";
 
 export default function DuaLipaSpotify() {
   const h1Class = "text-3xl font-bold mb-4 text-pink-300";
+
+  function SwitchToBackupSrc(e: MediaErrorEvent, backupFile: string): void {
+    e.target.src = `https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/${backupFile}.mp4`;
+  }
 
   return (
     <main className="flex min-h-screen flex-col overflow-x-clip">
@@ -49,17 +54,9 @@ export default function DuaLipaSpotify() {
           <MediaPlayer
             className="w-2/3 sm:w-1/4"
             title="Levitating Loop"
-            src={[
-              {
-                src: "https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/LevitatingLoop.mp4",
-                type: "video/mp4",
-              },
-              {
-                src: "https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/LevitatingLoop.webm",
-                type: "video/webm",
-              },
-            ]}
+            src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/LevitatingLoop.webm"
             load="eager"
+            onError={(e) => SwitchToBackupSrc(e, "LevitatingLoop")}
             controls
             autoplay
             muted

--- a/app/art/dua-lipa-spotify/page.tsx
+++ b/app/art/dua-lipa-spotify/page.tsx
@@ -49,22 +49,23 @@ export default function DuaLipaSpotify() {
           <MediaPlayer
             className="w-2/3 sm:w-1/4"
             title="Levitating Loop"
+            src={[
+              {
+                src: "https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/LevitatingLoop.webm",
+                type: "video/webm",
+              },
+              {
+                src: "https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/LevitatingLoop.mp4",
+                type: "video/mp4",
+              },
+            ]}
             load="eager"
             controls
             autoplay
             muted
             loop
           >
-            <MediaOutlet>
-              <source
-                src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/LevitatingLoop.webm"
-                type="video/webm"
-              />
-              <source
-                src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/LevitatingLoop.mp4"
-                type="video/mp4"
-              />
-            </MediaOutlet>
+            <MediaOutlet />
           </MediaPlayer>
           <MediaPlayer
             className="w-2/3 sm:w-1/4"

--- a/app/art/dua-lipa-spotify/page.tsx
+++ b/app/art/dua-lipa-spotify/page.tsx
@@ -57,12 +57,12 @@ export default function DuaLipaSpotify() {
           >
             <MediaOutlet>
               <source
-                src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/LevitatingLoop.mp4"
-                type="video/mp4"
-              />
-              <source
                 src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/LevitatingLoop.webm"
                 type="video/webm"
+              />
+              <source
+                src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/LevitatingLoop.mp4"
+                type="video/mp4"
               />
             </MediaOutlet>
           </MediaPlayer>

--- a/app/art/dua-lipa-spotify/page.tsx
+++ b/app/art/dua-lipa-spotify/page.tsx
@@ -52,6 +52,7 @@ export default function DuaLipaSpotify() {
             src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/LevitatingLoop.webm"
             backupSrc="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/LevitatingLoop.mp4"
             load="eager"
+            playsinline
             controls
             autoplay
             muted
@@ -63,6 +64,7 @@ export default function DuaLipaSpotify() {
             src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/BreakMyHeartLoop.webm"
             backupSrc="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/BreakMyHeartLoop.mp4"
             load="eager"
+            playsinline
             controls
             autoplay
             muted
@@ -74,6 +76,7 @@ export default function DuaLipaSpotify() {
             src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/PhysicalLoop.webm"
             backupSrc="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/PhysicalLoop.mp4"
             load="eager"
+            playsinline
             controls
             autoplay
             muted

--- a/app/art/dua-lipa-spotify/page.tsx
+++ b/app/art/dua-lipa-spotify/page.tsx
@@ -6,8 +6,6 @@
 import SimpleTopbar from "@/components/common/simple-topbar";
 import TitleImage from "@/components/common/title-image";
 import VideoPlayer from "@/components/common/video-player";
-import { MediaPlayer, MediaOutlet } from "@vidstack/react";
-import { MediaErrorEvent } from "vidstack";
 
 export default function DuaLipaSpotify() {
   const h1Class = "text-3xl font-bold mb-4 text-pink-300";
@@ -47,13 +45,14 @@ export default function DuaLipaSpotify() {
         <h1 className={h1Class} id="videos">
           Videos
         </h1>
-        <div className="flex flex-col sm:flex-row mt-8 w-[98vw] justify-between items-center space-y-4">
+        <div className="flex flex-col sm:flex-row mt-8 justify-between items-center space-y-4">
           <VideoPlayer
             className="w-2/3 sm:w-1/4"
             title="Levitating Loop"
             src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/LevitatingLoop.webm"
             backupSrc="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/LevitatingLoop.mp4"
             load="eager"
+            controls
             autoplay
             muted
             loop
@@ -68,9 +67,7 @@ export default function DuaLipaSpotify() {
             autoplay
             muted
             loop
-          >
-            <MediaOutlet />
-          </VideoPlayer>
+          />
           <VideoPlayer
             className="w-2/3 sm:w-1/4"
             title="Physical Loop"
@@ -81,9 +78,7 @@ export default function DuaLipaSpotify() {
             autoplay
             muted
             loop
-          >
-            <MediaOutlet />
-          </VideoPlayer>
+          />
         </div>
       </div>
     </main>

--- a/app/art/dua-lipa-spotify/page.tsx
+++ b/app/art/dua-lipa-spotify/page.tsx
@@ -51,12 +51,12 @@ export default function DuaLipaSpotify() {
             title="Levitating Loop"
             src={[
               {
-                src: "https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/LevitatingLoop.webm",
-                type: "video/webm",
-              },
-              {
                 src: "https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/LevitatingLoop.mp4",
                 type: "video/mp4",
+              },
+              {
+                src: "https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/LevitatingLoop.webm",
+                type: "video/webm",
               },
             ]}
             load="eager"

--- a/app/art/dua-lipa-spotify/page.tsx
+++ b/app/art/dua-lipa-spotify/page.tsx
@@ -5,15 +5,12 @@
 
 import SimpleTopbar from "@/components/common/simple-topbar";
 import TitleImage from "@/components/common/title-image";
+import VideoPlayer from "@/components/common/video-player";
 import { MediaPlayer, MediaOutlet } from "@vidstack/react";
 import { MediaErrorEvent } from "vidstack";
 
 export default function DuaLipaSpotify() {
   const h1Class = "text-3xl font-bold mb-4 text-pink-300";
-
-  function SwitchToBackupSrc(e: MediaErrorEvent, backupFile: string): void {
-    e.target.src = `https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/${backupFile}.mp4`;
-  }
 
   return (
     <main className="flex min-h-screen flex-col overflow-x-clip">
@@ -51,59 +48,42 @@ export default function DuaLipaSpotify() {
           Videos
         </h1>
         <div className="flex flex-col sm:flex-row mt-8 w-[98vw] justify-between items-center space-y-4">
-          <MediaPlayer
+          <VideoPlayer
             className="w-2/3 sm:w-1/4"
             title="Levitating Loop"
             src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/LevitatingLoop.webm"
+            backupSrc="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/LevitatingLoop.mp4"
             load="eager"
-            onError={(e) => SwitchToBackupSrc(e, "LevitatingLoop")}
+            autoplay
+            muted
+            loop
+          />
+          <VideoPlayer
+            className="w-2/3 sm:w-1/4"
+            title="Break My Heart Loop"
+            src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/BreakMyHeartLoop.webm"
+            backupSrc="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/BreakMyHeartLoop.mp4"
+            load="eager"
             controls
             autoplay
             muted
             loop
           >
             <MediaOutlet />
-          </MediaPlayer>
-          <MediaPlayer
-            className="w-2/3 sm:w-1/4"
-            title="Break My Heart Loop"
-            load="eager"
-            controls
-            autoplay
-            muted
-            loop
-          >
-            <MediaOutlet>
-              <source
-                src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/BreakMyHeartLoop.mp4"
-                type="video/mp4"
-              />
-              <source
-                src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/BreakMyHeartLoop.webm"
-                type="video/webm"
-              />
-            </MediaOutlet>
-          </MediaPlayer>
-          <MediaPlayer
+          </VideoPlayer>
+          <VideoPlayer
             className="w-2/3 sm:w-1/4"
             title="Physical Loop"
+            src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/PhysicalLoop.webm"
+            backupSrc="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/PhysicalLoop.mp4"
             load="eager"
             controls
             autoplay
             muted
             loop
           >
-            <MediaOutlet>
-              <source
-                src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/PhysicalLoop.mp4"
-                type="video/mp4"
-              />
-              <source
-                src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/PhysicalLoop.webm"
-                type="video/webm"
-              />
-            </MediaOutlet>
-          </MediaPlayer>
+            <MediaOutlet />
+          </VideoPlayer>
         </div>
       </div>
     </main>

--- a/app/art/take-a-chance/page.tsx
+++ b/app/art/take-a-chance/page.tsx
@@ -96,6 +96,7 @@ export default function TakeAChance() {
             src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/take-a-chance-projection-map-outro.webm"
             backupSrc="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/take-a-chance-projection-map-outro.mp4"
             load="idle"
+            playsinline
             controls
             className="aspect-video"
           />
@@ -114,6 +115,7 @@ export default function TakeAChance() {
             src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/kumler-chapel-take-a-chance.webm"
             backupSrc="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/kumler-chapel-take-a-chance.mp4"
             load="idle"
+            playsinline
             controls
             className="aspect-video"
           />
@@ -125,6 +127,7 @@ export default function TakeAChance() {
             src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/take-a-chance-projection-map-final.webm"
             backupSrc="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/take-a-chance-projection-map-final.mp4"
             load="idle"
+            playsinline
             controls
             className="aspect-video"
           />

--- a/app/art/take-a-chance/page.tsx
+++ b/app/art/take-a-chance/page.tsx
@@ -5,6 +5,7 @@
 
 import SimpleTopbar from "@/components/common/simple-topbar";
 import TitleImage from "@/components/common/title-image";
+import VideoPlayer from "@/components/common/video-player";
 import VideoPlayerControls from "@/components/common/video-player-controls";
 import { MediaOutlet, MediaPlayer } from "@vidstack/react";
 import Image from "next/image";
@@ -90,23 +91,14 @@ export default function TakeAChance() {
         </p>
         <br></br>
         <div className="relative mx-4 sm:mx-8 md:mx-24 mb-4 fullscreen:h-screen">
-          <MediaPlayer
+          <VideoPlayer
             title="Take a Chance Outro"
+            src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/take-a-chance-projection-map-outro.webm"
+            backupSrc="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/take-a-chance-projection-map-outro.mp4"
             load="idle"
+            controls
             className="aspect-video"
-          >
-            <MediaOutlet>
-              <source
-                src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/take-a-chance-projection-map-outro.mp4"
-                type="video/mp4"
-              />
-              <source
-                src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/take-a-chance-projection-map-outro.webm"
-                type="video/webm"
-              />
-            </MediaOutlet>
-            <VideoPlayerControls title='"Take a Chance" Outro' />
-          </MediaPlayer>
+          />
         </div>
         <h1 className={h1Class} id="final-product">
           Final Product
@@ -117,43 +109,25 @@ export default function TakeAChance() {
         </p>
         <br></br>
         <div className="relative mx-4 sm:mx-8 md:mx-24 mb-4 fullscreen:h-screen">
-          <MediaPlayer
+          <VideoPlayer
             title="Take a Chance Live @ Kumler Chapel"
+            src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/kumler-chapel-take-a-chance.webm"
+            backupSrc="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/kumler-chapel-take-a-chance.mp4"
             load="idle"
+            controls
             className="aspect-video"
-          >
-            <MediaOutlet>
-              <source
-                src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/kumler-chapel-take-a-chance.mp4"
-                type="video/mp4"
-              />
-              <source
-                src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/kumler-chapel-take-a-chance.webm"
-                type="video/webm"
-              />
-            </MediaOutlet>
-            <VideoPlayerControls title='"Take a Chance" Live @ Kumler Chapel' />
-          </MediaPlayer>
+          />
         </div>
         <p>And here is the final video output that was projected:</p>
         <div className="relative mx-4 sm:mx-8 md:mx-24 mt-4 fullscreen:h-screen">
-          <MediaPlayer
+          <VideoPlayer
             title="Take a Chance Projection Map"
+            src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/take-a-chance-projection-map-final.webm"
+            backupSrc="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/take-a-chance-projection-map-final.mp4"
             load="idle"
+            controls
             className="aspect-video"
-          >
-            <MediaOutlet>
-              <source
-                src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/take-a-chance-projection-map-final.mp4"
-                type="video/mp4"
-              />
-              <source
-                src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/take-a-chance-projection-map-final.webm"
-                type="video/webm"
-              />
-            </MediaOutlet>
-            <VideoPlayerControls title='"Take a Chance" Projection Map' />
-          </MediaPlayer>
+          />
         </div>
       </div>
     </main>

--- a/app/games/pride-and-accomplishment/page.tsx
+++ b/app/games/pride-and-accomplishment/page.tsx
@@ -7,7 +7,7 @@ import CollapsibleBox from "@/components/common/collapsible-box";
 import FloatQuote from "@/components/common/float-quote";
 import SimpleTopbar from "@/components/common/simple-topbar";
 import TitleImage from "@/components/common/title-image";
-import { MediaOutlet, MediaPlayer } from "@vidstack/react";
+import VideoPlayer from "@/components/common/video-player";
 import Link from "next/link";
 import SyntaxHighlighter from "react-syntax-highlighter";
 import { tomorrowNightEighties } from "react-syntax-highlighter/dist/cjs/styles/hljs";
@@ -127,24 +127,16 @@ export default function PrideAndAccomplishment() {
           admission.
         </p>
         <div className="relative md:left-1/4 md:w-1/2 my-8">
-          <MediaPlayer
+          <VideoPlayer
             title="Pride and Accomplishment Demo"
+            src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/pride-and-accomplishment-demo.webm"
+            backupSrc="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/pride-and-accomplishment-demo.mp4"
             load="idle"
+            playsinline
             autoplay
             muted
             loop
-          >
-            <MediaOutlet>
-              <source
-                src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/pride-and-accomplishment-demo.mp4"
-                type="video/mp4"
-              />
-              <source
-                src="https://kentaiga-portfolio-images.s3.us-east-2.amazonaws.com/pride-and-accomplishment-demo.webm"
-                type="video/webm"
-              />
-            </MediaOutlet>
-          </MediaPlayer>
+          />
         </div>
         <h1 className={h1Class} id="the-process">
           The Process

--- a/components/common/video-player-controls.tsx
+++ b/components/common/video-player-controls.tsx
@@ -28,12 +28,10 @@ import {
 import { MdOutlineSpeed } from "react-icons/md";
 
 export default function VideoPlayerControls(props: any) {
+  const parentClass = `${props.className} opacity-0 can-control:opacity-100 pointer-events-none absolute inset-0 z-10 flex h-full flex-col justify-between text-white transition-opacity duration-200 ease-linear`;
+
   return (
-    <div
-      className="opacity-0 can-control:opacity-100 pointer-events-none absolute inset-0 z-10 flex h-full flex-col justify-between text-white transition-opacity duration-200 ease-linear"
-      role="group"
-      aria-label="Media Controls"
-    >
+    <div className={parentClass} role="group" aria-label="Media Controls">
       <MediaControlGroup>
         <h1 className="text-md md:text-xl font-bold p-4">{props.title}</h1>
       </MediaControlGroup>

--- a/components/common/video-player.tsx
+++ b/components/common/video-player.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { MediaPlayer, MediaOutlet } from "@vidstack/react";
+import VideoPlayerControls from "./video-player-controls";
+import { MediaErrorEvent } from "vidstack";
+
+export default function VideoPlayer(props: any): React.JSX.Element {
+  function SwitchToBackupSrc(e: MediaErrorEvent, backupFile: string): void {
+    e.target.src = backupFile;
+  }
+
+  return (
+    <MediaPlayer
+      className={props.className}
+      title={props.title}
+      src={props.src}
+      load={props.load}
+      onError={(e) => SwitchToBackupSrc(e, props.backupSrc)}
+      autoplay={props.autoplay}
+      muted={props.muted}
+      loop={props.loop}
+    >
+      <MediaOutlet />
+      <VideoPlayerControls />
+    </MediaPlayer>
+  );
+}

--- a/components/common/video-player.tsx
+++ b/components/common/video-player.tsx
@@ -1,4 +1,5 @@
-import React from "react";
+import React, { use } from "react";
+import { useEffect } from "react";
 import { MediaPlayer, MediaOutlet } from "@vidstack/react";
 import VideoPlayerControls from "./video-player-controls";
 import { MediaErrorEvent } from "vidstack";
@@ -8,6 +9,13 @@ export default function VideoPlayer(props: any): React.JSX.Element {
     e.target.src = backupFile;
   }
 
+  let controlsClassName: string;
+  if (props.controls) {
+    controlsClassName = "visible";
+  } else {
+    controlsClassName = "hidden";
+  }
+
   return (
     <MediaPlayer
       className={`relative + ${props.className}`}
@@ -15,12 +23,13 @@ export default function VideoPlayer(props: any): React.JSX.Element {
       src={props.src}
       load={props.load}
       onError={(e) => SwitchToBackupSrc(e, props.backupSrc)}
+      playsinline={props.playsinline}
       autoplay={props.autoplay}
       muted={props.muted}
       loop={props.loop}
     >
       <MediaOutlet />
-      <VideoPlayerControls />
+      <VideoPlayerControls title={props.title} className={controlsClassName} />
     </MediaPlayer>
   );
 }

--- a/components/common/video-player.tsx
+++ b/components/common/video-player.tsx
@@ -10,7 +10,7 @@ export default function VideoPlayer(props: any): React.JSX.Element {
 
   return (
     <MediaPlayer
-      className={props.className}
+      className={`relative + ${props.className}`}
       title={props.title}
       src={props.src}
       load={props.load}


### PR DESCRIPTION
This PR fixes mobile rendering issues by providing MP4 alternatives to the videos provided and automatically using WEBM if the device supports it. There are still some issues in regard to how iOS renders these videos since it attempts to render a large chunk of a video before displaying them properly. This will be mentioned in a new issue.